### PR TITLE
Fix annotations moved 1 line bottom and 1 col left

### DIFF
--- a/src/com/jokerzoid/intellij/plugin/stylelint/ProcessManager.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/ProcessManager.java
@@ -73,7 +73,7 @@ class ProcessManager {
 
         /* Since IntelliJ uses offsets instead of (line, col) we need to convert them */
         output.getWarnings().forEach(warning -> {
-            warning.setOffset(StringUtil.lineColToOffset(text, warning.getLine(), warning.getColumn()));
+            warning.setOffset(StringUtil.lineColToOffset(text, warning.getLine() - 1, warning.getColumn()));
         });
 
         return output;

--- a/src/com/jokerzoid/intellij/plugin/stylelint/ProcessManager.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/ProcessManager.java
@@ -73,7 +73,7 @@ class ProcessManager {
 
         /* Since IntelliJ uses offsets instead of (line, col) we need to convert them */
         output.getWarnings().forEach(warning -> {
-            warning.setOffset(StringUtil.lineColToOffset(text, warning.getLine() - 1, warning.getColumn()));
+            warning.setOffset(StringUtil.lineColToOffset(text, warning.getLine() - 1, warning.getColumn() - 1));
         });
 
         return output;

--- a/src/com/jokerzoid/intellij/plugin/stylelint/StylelintAnnotator.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/StylelintAnnotator.java
@@ -47,7 +47,7 @@ public class StylelintAnnotator extends ExternalAnnotator<PsiFile, List<Stylelin
         warnings.forEach(warning -> {
             final PsiElement element = PsiUtil.getElementAtOffset(file, warning.getOffset());
 
-            holder.createErrorAnnotation(element, warning.getText());
+            holder.createWarningAnnotation(element, warning.getText());
             LOGGER.info("Apply");
         });
     }


### PR DESCRIPTION
The annotations are skewed by 1 col and 1 line to bottom right, so I had to adjust it.
I also change severity of annotations from Errors to Warnings.
Tested in IDEA 2016.3.