### PR TITLE
Auto detect stylelint executable

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+
+indent_style = space
+indent_size = 2
+
+max_line_length = 80
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.DS_Store
 /.idea/
 /out/
 /stylelint-plugin.iml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# stylelint-plugin
-Stylelint plugin for all products based on IntelliJ Platform (IntelliJ IDEA, RubyMine, WebStorm, PhpStorm, PyCharm, AppCode, etc.)
+# StyleLint plugin for IntelliJ
+
+Stylelint plugin for all products based on the IntelliJ Platform (IntelliJ
+IDEA, RubyMine, WebStorm, PhpStorm, PyCharm, AppCode, etc.)
+
+## How to use
+
+You can use the program in two ways:
+
+1. Install stylelint globally (`yarn global add stylelint`)
+2. Use project stylelint (`yarn add --dev stylelint`).
+
+If you don't install stylelint globally and the project doesn't have it
+installed, the plugin will silently quit.

--- a/resources/strings_en.properties
+++ b/resources/strings_en.properties
@@ -1,0 +1,8 @@
+settings_title = Stylelint executable
+settings_button = ...
+settings_caption=Specify a path above to disable automatic searching.\n\n\
+  Otherwise, the plugin will automatically search in the following locations:\n\n\
+  1. The active project's node_modules directory\n\
+  2. The globally installed node modules.\n\
+  3. The globally installed Yarn packages.\n\
+  4. The PATH environment variable.

--- a/resources/strings_nl.properties
+++ b/resources/strings_nl.properties
@@ -1,0 +1,8 @@
+settings_title = Stylelint programma
+settings_button = ...
+settings_caption=Het pad hierboven schakelt automatisch zoeken uit.\n\n\
+  Er wordt automatisch gezocht op de volgende locaties:\n\n\
+  1. In de node_modules map in het actieve project\n\
+  2. In de globaal geinstalleerde NPM pakketten.\n\
+  3. In de globaal geinstalleerde Yarn pakketten.\n\
+  4. In de PATH omgevingsvariabele.

--- a/src/com/jokerzoid/intellij/plugin/stylelint/ProjectConfigurationPanel.form
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/ProjectConfigurationPanel.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.jokerzoid.intellij.plugin.stylelint.ProjectConfigurationPanel">
-  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="418" height="212"/>
+      <xy x="20" y="20" width="413" height="323"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -24,7 +24,7 @@
         </constraints>
         <properties>
           <labelFor value="28730"/>
-          <text value="Stylelint executable"/>
+          <text resource-bundle="strings" key="settings_title"/>
         </properties>
       </component>
       <component id="180ae" class="javax.swing.JButton" binding="executableDirButton">
@@ -32,12 +32,23 @@
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="..."/>
+          <text resource-bundle="strings" key="settings_button"/>
+        </properties>
+      </component>
+      <component id="6bc3a" class="javax.swing.JTextPane" binding="descriptionPane">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="10"/>
+          </grid>
+        </constraints>
+        <properties>
+          <editable value="false"/>
+          <text resource-bundle="strings" key="settings_caption"/>
         </properties>
       </component>
       <vspacer id="902ec">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
     </children>

--- a/src/com/jokerzoid/intellij/plugin/stylelint/ProjectConfigurationPanel.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/ProjectConfigurationPanel.java
@@ -24,6 +24,7 @@ public class ProjectConfigurationPanel implements SearchableConfigurable {
   private JTextField executableTextField;
   private JButton executableDirButton;
   private JPanel rootPanel;
+  private JTextPane descriptionPane;
   private JFileChooser fileChooser;
 
   private ProjectService state;
@@ -66,7 +67,7 @@ public class ProjectConfigurationPanel implements SearchableConfigurable {
   @Override
   public void reset() {
     if (StringUtils.isEmpty(state.executable)) {
-      executableTextField.setText(ProcessManager.getDefaultExePath());
+      executableTextField.setText(StringUtils.EMPTY);
     } else {
       executableTextField.setText(state.executable);
     }

--- a/src/com/jokerzoid/intellij/plugin/stylelint/ProjectConfigurationPanel.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/ProjectConfigurationPanel.java
@@ -4,16 +4,14 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.project.Project;
-
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.io.File;
-
-import javax.swing.*;
 
 /**
  * @author rrosa

--- a/src/com/jokerzoid/intellij/plugin/stylelint/ProjectService.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/ProjectService.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.components.State;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.xmlb.XmlSerializerUtil;
-
 import org.jetbrains.annotations.Nullable;
 
 /**

--- a/src/com/jokerzoid/intellij/plugin/stylelint/ProjectService.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/ProjectService.java
@@ -35,6 +35,9 @@ public class ProjectService implements PersistentStateComponent<ProjectService> 
   @Override
   public void loadState(ProjectService state) {
     XmlSerializerUtil.copyBean(state, this);
+    if (this.executable.equals("/stylelint") || this.executable.equals("/stylelint.cmd")) {
+      this.executable = "";
+    }
   }
 
 }

--- a/src/com/jokerzoid/intellij/plugin/stylelint/StylelintAnnotator.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/StylelintAnnotator.java
@@ -7,7 +7,6 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiUtilCore;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/com/jokerzoid/intellij/plugin/stylelint/executable/ExecutableProvider.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/executable/ExecutableProvider.java
@@ -1,0 +1,15 @@
+package com.jokerzoid.intellij.plugin.stylelint.executable;
+
+import com.intellij.openapi.project.Project;
+
+public interface ExecutableProvider {
+
+  /**
+   * Returns a path to Stylelint, which does or does not exist.
+   *
+   * @param project Project to look in
+   * @return Absolute path to the stylelint executable
+   */
+  String getPath(Project project);
+
+}

--- a/src/com/jokerzoid/intellij/plugin/stylelint/executable/GlobalScriptExecutable.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/executable/GlobalScriptExecutable.java
@@ -1,0 +1,119 @@
+package com.jokerzoid.intellij.plugin.stylelint.executable;
+
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Extends the executable to contain a cache that is invalidated whenever the target directory gets changed.
+ */
+public abstract class GlobalScriptExecutable implements ExecutableProvider {
+
+  /**
+   * Miliseconds to wait between checks, defaults to 60s
+   */
+  private static final long WAIT_DURATION = 60L * 1000L;
+
+  /**
+   * Cached path to binaries
+   */
+  private String resolvedBinaryDir = null;
+
+  /**
+   * Cached found executable
+   */
+  private String foundExecutable = null;
+
+  /**
+   * Timeout until next search
+   */
+  private long timeout = 0L;
+
+  /**
+   * Command to run to determine directory
+   *
+   * @return A command name, with optional args
+   */
+  @NotNull
+  abstract String getBinaryDirCommand();
+
+  private String getBinaryDir() {
+    if (resolvedBinaryDir != null) {
+      return resolvedBinaryDir.isEmpty() ? null : resolvedBinaryDir;
+    }
+
+    // Set binary dir to empty string, which prevents further runs
+    resolvedBinaryDir = "";
+
+    // Start a new process
+    try {
+      Process proc = Runtime.getRuntime().exec(getBinaryDirCommand());
+      // Wait for it to finish
+      try {
+        // Wait a max of 100ms, otherwise return null
+        if (!proc.waitFor(100L, TimeUnit.MILLISECONDS)) {
+          return null;
+        }
+      } catch (InterruptedException e) {
+        return null;
+      }
+
+      // Get the return value of the process into a reader
+      InputStream stream = proc.getInputStream();
+      ObjectInputStream reader = new ObjectInputStream(stream);
+
+      // Read data, close stream
+      String result = reader.available() > 0 ? reader.readUTF() : "";
+      reader.close();
+
+      // Save that longest line (or an empty value)
+      resolvedBinaryDir = result.trim();
+    } catch (IOException e) {
+      return null;
+    }
+
+    // Return path or null on empty
+    return resolvedBinaryDir.isEmpty() ? null : resolvedBinaryDir;
+  }
+
+  /**
+   * Returns the path. Once an executable has been found, it'll be used forever for that project.
+   *
+   * @param project Project to look in
+   * @return String to executable, or null if none
+   */
+  @Override
+  public String getPath(Project project) {
+
+    // Return path
+    if (foundExecutable != null) {
+      return foundExecutable.isEmpty() ? null : foundExecutable;
+    } else if (timeout > System.currentTimeMillis() || getBinaryDir() == null) {
+      return null;
+    }
+
+    // Sleep for a bit after this run
+    timeout = System.currentTimeMillis() + WAIT_DURATION;
+
+    // Check if vendor bin directory exists
+    File nodeBinPath = new File(getBinaryDir());
+    if (!nodeBinPath.exists() || !nodeBinPath.isDirectory()) {
+      return null;
+    }
+
+    // Check if file exists in that directory
+    File binFile = new File(nodeBinPath.getAbsolutePath() + File.separator + StylelintExecutableHelper.getBinaryNameForOs());
+    if (binFile.exists() && binFile.isFile()) {
+      foundExecutable = binFile.getAbsolutePath();
+      return foundExecutable;
+    }
+
+    return null;
+  }
+
+}

--- a/src/com/jokerzoid/intellij/plugin/stylelint/executable/NpmGlobalExecutable.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/executable/NpmGlobalExecutable.java
@@ -1,0 +1,15 @@
+package com.jokerzoid.intellij.plugin.stylelint.executable;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Locates the stylelint package if it's installed using {@code npm install -g stylelint}.
+ */
+class NpmGlobalExecutable extends GlobalScriptExecutable implements ExecutableProvider {
+
+  @NotNull
+  @Override
+  String getBinaryDirCommand() {
+    return "npm -g bin";
+  }
+}

--- a/src/com/jokerzoid/intellij/plugin/stylelint/executable/PathExecutable.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/executable/PathExecutable.java
@@ -1,0 +1,50 @@
+package com.jokerzoid.intellij.plugin.stylelint.executable;
+
+import com.intellij.openapi.project.Project;
+
+import java.io.File;
+
+/**
+ * Checks if the Stylelint binary exists on the path.
+ */
+public class PathExecutable implements ExecutableProvider {
+
+  /**
+   * Path to the stylelint binary, empty string if not found.
+   * <p>
+   * Since the PATH variable cannot change during execution, we're caching the response value indefinitely.
+   */
+  private String binaryPath = null;
+
+  @Override
+  public String getPath(Project project) {
+    // if we've already searched, use that data
+    if (binaryPath != null) {
+      return binaryPath.isEmpty() ? null : binaryPath;
+    }
+
+    // Find the path and split it by path separator
+    String systemPath = System.getenv("PATH");
+    String[] pathSections = systemPath.split(File.pathSeparator);
+
+    // Get the OS name
+    String binaryName = StylelintExecutableHelper.getBinaryNameForOs();
+
+    // Prepare variables
+    File testFile;
+    String foundPath = "";
+
+    // Loop through each section
+    for (String section : pathSections) {
+      testFile = new File(section + binaryName);
+      if (testFile.exists() && testFile.isFile() && testFile.canExecute()) {
+        foundPath = testFile.getAbsolutePath();
+        break;
+      }
+    }
+
+    // Cache result indefinitely and return value
+    binaryPath = foundPath;
+    return binaryPath.isEmpty() ? null : binaryPath;
+  }
+}

--- a/src/com/jokerzoid/intellij/plugin/stylelint/executable/ProjectExecutable.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/executable/ProjectExecutable.java
@@ -1,0 +1,74 @@
+package com.jokerzoid.intellij.plugin.stylelint.executable;
+
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Links to the stylelint binary if it's locally installed using the package.json file.
+ *
+ * @author Roelof Roos <github@roelof.io>
+ */
+public class ProjectExecutable implements ExecutableProvider {
+
+  /**
+   * Miliseconds to wait between checks, defaults to 60s
+   */
+  private static final long WAIT_DURATION = 60L * 1000L;
+
+  /**
+   * Contains timed caches, in case a directory does not exist.
+   */
+  private static Map<String, Long> timeLockMap = new HashMap<>();
+
+  /**
+   * Contains a map of cached values
+   */
+  private static Map<String, String> executableMap = new HashMap<>();
+
+  @NotNull
+  private Boolean shouldCheckAgain(String directory) {
+    return !timeLockMap.containsKey(directory) || timeLockMap.get(directory) < System.currentTimeMillis();
+  }
+
+  /**
+   * Returns the path. Once an executable has been found, it'll be used forever for that project.
+   *
+   * @param project Project to look in
+   * @return String to executable, or null if none
+   */
+  @Override
+  public String getPath(Project project) {
+    // Get project path
+    String rootPath = project.getBasePath();
+
+    // Check if found or waiting for next check
+    if (executableMap.containsKey(rootPath)) {
+      return executableMap.get(rootPath);
+    } else if (!shouldCheckAgain(rootPath)) {
+      return null;
+    }
+
+    // Lock the changes for a while
+    timeLockMap.put(rootPath, System.currentTimeMillis() + WAIT_DURATION);
+
+    // Get binaries directory
+    File nodeBinPath = new File(rootPath + File.separator + "node_modules/.bin");
+    if (!nodeBinPath.exists() || !nodeBinPath.isDirectory()) {
+      return null;
+    }
+
+    // Check if stylelint exists there
+    File binFile = new File(nodeBinPath.getAbsolutePath() + File.separator + StylelintExecutableHelper.getBinaryNameForOs());
+    if (binFile.exists() && binFile.isFile()) {
+      String executable = binFile.getAbsolutePath();
+      executableMap.put(rootPath, executable);
+      return executable;
+    }
+
+    return null;
+  }
+}

--- a/src/com/jokerzoid/intellij/plugin/stylelint/executable/StylelintExecutableHelper.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/executable/StylelintExecutableHelper.java
@@ -1,0 +1,77 @@
+package com.jokerzoid.intellij.plugin.stylelint.executable;
+
+import com.intellij.openapi.project.Project;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Links to the stylelint installation from a path set from the settings.
+ *
+ * @author Roelof Roos <github@roelof.io>
+ */
+public class StylelintExecutableHelper {
+
+  private static final Map<Project, String> executableDictionary = new HashMap<>();
+
+  /**
+   * Possible classes that can resolve a path to Stylelint
+   */
+  private final static ExecutableProvider[] executableProviders = new ExecutableProvider[]{
+    new ProjectExecutable(),
+    new NpmGlobalExecutable(),
+    new YarnGlobalExecutable(),
+    new PathExecutable(),
+  };
+
+  /**
+   * Return the name the program is most likely reachable over. For Windows this is somewhat unreliable as users may
+   * rename the {@code .cmd} to {@code .bat} or {@code .com}
+   *
+   * @return Returns the filename for stylelint, optionally with an extension
+   */
+  static String getBinaryNameForOs() {
+    String osName = StringUtils.defaultIfEmpty(System.getProperty("os.name"), "").toLowerCase();
+    String programName = "stylelint";
+
+    if (osName.contains("windows")) {
+      return programName.concat(".cmd");
+    }
+
+    return programName;
+  }
+
+  /**
+   * Finds the executable for the path. Cached indefinitely.
+   *
+   * @param project
+   * @return path to exectuable, or null if none was eligible
+   */
+  public String findExecutable(Project project) {
+    if (executableDictionary.containsKey(project)) {
+      return executableDictionary.get(project);
+    }
+
+    String foundPath = null;
+    File foundFile;
+    for (ExecutableProvider provider : executableProviders) {
+      foundPath = provider.getPath(project);
+      if (foundPath == null) {
+        continue;
+      }
+
+      foundFile = new File(foundPath);
+      if (!foundFile.exists() || !foundFile.isFile() || !foundFile.canExecute()) {
+        foundPath = null;
+        continue;
+      }
+
+      break;
+    }
+
+    executableDictionary.put(project, foundPath);
+    return foundPath;
+  }
+}

--- a/src/com/jokerzoid/intellij/plugin/stylelint/executable/YarnGlobalExecutable.java
+++ b/src/com/jokerzoid/intellij/plugin/stylelint/executable/YarnGlobalExecutable.java
@@ -1,0 +1,17 @@
+package com.jokerzoid.intellij.plugin.stylelint.executable;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Links to the stylelint binary if it's globally installed using {@code yarn global add stylelint}.
+ *
+ * @author Roelof Roos <github@roelof.io>
+ */
+public class YarnGlobalExecutable extends GlobalScriptExecutable implements ExecutableProvider {
+
+  @NotNull
+  @Override
+  String getBinaryDirCommand() {
+    return "yarn global bin";
+  }
+}


### PR DESCRIPTION
Hey,

I've taken the liberty to perform a serious overhaul on one aspect of the code: the way the `stylelint` binary is detected.

Now the plugin automatically looks in four places for the binary:

1. The `node_modules` directory in the project root
2. The globally installed npm modules (via `npm install -g stylelint`)
3. The user-globally installed Yarn packges (via `yarn global add stylelint`)
4. The `$PATH` variable

Items 2 and 3 use `npm bin -g` and `yarn global bin` respectively to determine where to look (those commands return the absolute path to the binaries directory) and the 1st item just checks for a `node_modules/.bin` directory. So that's a fix for #9.

It auto-adds `.cmd` to files on Windows, but shouldn't do that on Linux or Mac (so this fixes #3), should actually work with a previous commit, I just re-located the code into the `executable` package.

If a user has manually specified the path to stylelint, it's still being used and will disable the auto-check for files. To inform users of that fact I added a notice on the settings page and also added those strings to a resources file, so they can be translated (I translated them in Dutch for you already :wink:).

And I've added/edited some files that should make editing code more monogamous (`.editorconfig`) and will show off the plugin a lot better (the `README.md`)

----

**WARNING** I was not able to get it to test properly and the JetBrains docs are all but clear about that, so I don't actually know how stable it works... :confused: 